### PR TITLE
Added a Markdown render tab

### DIFF
--- a/script.py
+++ b/script.py
@@ -478,6 +478,9 @@ def ui():
         with gr.Column():
             with gr.Tab('Response'):
                 text_boxB = gr.Textbox(value=save_params["text_boxB"], lines=20, label = '', elem_classes=['textbox', 'add_scrollbar'], elem_id='textbox-polybook')
+            with gr.Tab('Markdown'):
+                btn_MarkdownRender = gr.Button('Render')
+                div_MarkdownRender = gr.Markdown()
             with gr.Tab('Keep'):
                 text_boxC = gr.Textbox(value=save_params["text_boxC"], lines=20, label = '', elem_classes=['textbox', 'add_scrollbar'], elem_id='textbox-polybook')
                                
@@ -552,6 +555,8 @@ def ui():
     stop_btn.click(stop_everything_event, None, None, queue=False)
     stop_btn2.click(stop_everything_event, None, None, queue=False)
     
+    btn_MarkdownRender.click(lambda x: x, text_boxB, div_MarkdownRender, queue=False)
+
     def cleartext(texttextOUT):
         global last_undo
 


### PR DESCRIPTION
Hi, I love this extension.

For my use case of LLM to learn foreign languages, I needed a Markdown render - so that my favorite browser dictionary extension could pick up the words in the DOM (it can't translate the inner value of textareas).

So here's a very simple addition - a Markdown render tab on the right column.